### PR TITLE
Modified Android's AR experience to be surface-triggered

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -120,8 +120,13 @@
   },
   "arTab": {
     "title": "AR Badges",
+    "title-android": "AR Map",
+    "comment":
+      "the description has a lot of white space because the interface needs it to force the UI to stretch across the screen",
     "description":
       "Use your camera to view the exhibit hall and bring your badge to life!                                           ",
+    "description-android":
+      "Use your camera to view the exhibit hall in augmented reality!                                                   ",
     "tipsTitle": "TIPS",
     "tips": [
       "Align badge within the frame",
@@ -129,9 +134,17 @@
       "Avoid reflections and glare",
       "Have fun!"
     ],
+    "tips-android": [
+      "Move device around to initialize",
+      "Once plane is detected, tap to place map",
+      "Have fun!"
+    ],
     "poweredBy": "Powered by",
     "viroUrl": "www.viromedia.com",
     "enterARButton": "ENTER AR",
     "notSupported": "AR Badges is not supported\n on this device ☹"
+  },
+  "arScreen": {
+    "usePlaneInstructions": "Look for surfaces and tap to place map"
   }
 }

--- a/src/views/screens/ar-screen/ar-screen.tsx
+++ b/src/views/screens/ar-screen/ar-screen.tsx
@@ -7,7 +7,9 @@ import {
   Animated,
   Easing,
   Dimensions,
+  Platform,
 } from "react-native"
+import { Text } from "../../shared/text"
 import { NavigationScreenProps } from "react-navigation"
 import { ViroARSceneNavigator } from "react-viro"
 import ARInitializationUI from "./arscenes/ARInitializationUI.js"
@@ -41,6 +43,24 @@ const arInitializationUIStyle: ViewStyle = {
   alignItems: "center",
 }
 
+const usePlaneInstructions: ViewStyle = {
+  position: "absolute",
+  top: 0,
+  left: 0,
+  width: "100%",
+  height: 140,
+  justifyContent: "center",
+  alignItems: "center",
+  backgroundColor: "#292930B3",
+}
+
+const usePlanesButton: ViewStyle = {
+  position: "absolute",
+  height: 60,
+  width: 180,
+  bottom: 30,
+}
+
 const overlayImage: ViewStyle = {
   flex: 1,
   position: "absolute",
@@ -60,6 +80,8 @@ export class ARScreen extends React.Component<ARScreenProps, {}> {
       arInitialized: false,
       hasBadgeBeenFound: false,
       badgeOpacity: new Animated.Value(1),
+      instructionsOpacity: new Animated.Value(1),
+      usePlanes: Platform.OS == "android", // usePlanes if we're on Android
     }
 
     this.onARInitialized = this.onARInitialized.bind(this)
@@ -92,10 +114,16 @@ export class ARScreen extends React.Component<ARScreenProps, {}> {
         hasBadgeBeenFound: true,
       })
     })
+
+    Animated.timing(this.state.instructionsOpacity, {
+      toValue: 0,
+      duration: 1000,
+      easing: Easing.linear,
+    }).start()
   }
 
   getBadgeFrame() {
-    if (!this.state.hasBadgeBeenFound) {
+    if (!this.state.hasBadgeBeenFound && Platform.OS != "android") {
       return (
         <Animated.Image
           style={{ ...overlayImage, opacity: this.state.badgeOpacity }}
@@ -120,11 +148,22 @@ export class ARScreen extends React.Component<ARScreenProps, {}> {
     }
   }
 
+  getUsePlanesInstructions() {
+    if (this.state.usePlanes && !this.state.hasBadgeBeenFound) {
+      return (
+        <Animated.View style={{ ...usePlaneInstructions, opacity: this.state.instructionsOpacity }}>
+          <Text preset="body" tx="arScreen.usePlaneInstructions" style={{ fontSize: 20 }} />
+        </Animated.View>
+      )
+    }
+  }
+
   render() {
     return (
       <View style={{ flex: 1 }}>
         <ViroARSceneNavigator
           apiKey={"94B48744-8E99-4F49-BD71-845EAE94F5B4"}
+          viroAppProps={{ usePlanes: this.state.usePlanes }}
           initialScene={{
             scene: require("./arscenes/RecognizeBadgeScene"),
             passProps: {
@@ -135,6 +174,7 @@ export class ARScreen extends React.Component<ARScreenProps, {}> {
         />
 
         {this.getBadgeFrame()}
+        {this.getUsePlanesInstructions()}
 
         {this.getARInitializationUI()}
 

--- a/src/views/screens/ar-screen/arscenes/ViroARPlaneSelector.js
+++ b/src/views/screens/ar-screen/arscenes/ViroARPlaneSelector.js
@@ -1,0 +1,157 @@
+/**
+ This is a slightly modified version of the ViroARPlaneSelector under 
+ /node_modules/react-viro/components/AR/ViroARPlaneSelector.js
+
+ The only change is in line 126 where we invoke the given onClick prop even before a plane
+ has been selected (or rather, when a plane is selected too)
+*/
+
+import { requireNativeComponent, View, StyleSheet, findNodeHandle } from "react-native"
+import React, { Component } from "react"
+import PropTypes from "prop-types"
+
+var createReactClass = require("create-react-class")
+
+import { ViroMaterials, ViroARPlane, ViroQuad, ViroNode } from "react-viro"
+
+var _maxPlanes = 15
+var _planePrefix = "ViroARPlaneSelector_Plane_"
+
+/**
+ * This component wraps the logic required to enable user selection
+ * of an AR plane. This currently only allows for 1 plane to be selected,
+ * but could easily be modified to allow for more planes.
+ */
+var ViroARPlaneSelector = createReactClass({
+  propTypes: {
+    ...View.propTypes,
+    maxPlanes: PropTypes.number,
+    minHeight: PropTypes.number,
+    minWidth: PropTypes.number,
+    alignment: PropTypes.oneOf([
+      "Horizontal",
+      "HorizontalUpward",
+      "HorizontalDownward",
+      "Vertical",
+    ]),
+    visible: PropTypes.bool,
+    opacity: PropTypes.number,
+    ignoreEventHandling: PropTypes.bool,
+    dragType: PropTypes.oneOf(["FixedDistance", "FixedToWorld", "FixedToPlane"]),
+    dragPlane: PropTypes.shape({
+      planePoint: PropTypes.arrayOf(PropTypes.number),
+      planeNormal: PropTypes.arrayOf(PropTypes.number),
+      maxDistance: PropTypes.number,
+    }),
+
+    onHover: PropTypes.func,
+    onClick: PropTypes.func,
+    onClickState: PropTypes.func,
+    onTouch: PropTypes.func,
+    onScroll: PropTypes.func,
+    onSwipe: PropTypes.func,
+    onDrag: PropTypes.func,
+    onPinch: PropTypes.func,
+    onRotate: PropTypes.func,
+    onFuse: PropTypes.oneOfType([
+      PropTypes.shape({
+        callback: PropTypes.func.isRequired,
+        timeToFuse: PropTypes.number,
+      }),
+      PropTypes.func,
+    ]),
+    onCollision: PropTypes.func,
+    viroTag: PropTypes.string,
+    onAnchorFound: PropTypes.func,
+    onAnchorUpdated: PropTypes.func,
+    onAnchorRemoved: PropTypes.func,
+    onPlaneSelected: PropTypes.func,
+  },
+
+  getInitialState: function() {
+    return {
+      selectedSurface: -1,
+      foundARPlanes: [],
+    }
+  },
+
+  render: function() {
+    // Uncomment this line to check for misnamed props
+    //checkMisnamedProps("ViroARPlaneSelector", this.props);
+
+    return <ViroNode>{this._getARPlanes()}</ViroNode>
+  },
+
+  _getARPlanes() {
+    if (this.state.selectedSurface == -1) {
+      let arPlanes = []
+      let numPlanes = this.props.maxPlanes || _maxPlanes
+      for (var i = 0; i < numPlanes; i++) {
+        let foundARPlane = this.state.foundARPlanes[i]
+        let surfaceWidth = foundARPlane ? foundARPlane.width : 0
+        let surfaceHeight = foundARPlane ? foundARPlane.height : 0
+        let surfacePosition = foundARPlane ? foundARPlane.center : [0, 0, 0]
+        arPlanes.push(
+          <ViroARPlane
+            key={_planePrefix + i}
+            minWidth={this.props.minWidth}
+            minHeight={this.props.minHeight}
+            alignment={this.props.alignment}
+            onAnchorUpdated={this._onARPlaneUpdated(i)}
+          >
+            <ViroQuad
+              materials={"ViroARPlaneSelector_Translucent"}
+              onClick={this._getOnClickSurface(i)}
+              position={surfacePosition}
+              width={surfaceWidth}
+              height={surfaceHeight}
+              rotation={[-90, 0, 0]}
+            />
+          </ViroARPlane>,
+        )
+      }
+      return arPlanes
+    } else {
+      return <ViroARPlane key={_planePrefix + this.state.selectedSurface} {...this.props} />
+    }
+  },
+
+  _getOnClickSurface(index) {
+    return (position, source) => {
+      this.setState({ selectedSurface: index })
+      this._onPlaneSelected(this.state.foundARPlanes[index])
+      this.props.onClick(position, source)
+    }
+  },
+
+  _onARPlaneUpdated(index) {
+    return updateMap => {
+      this.state.foundARPlanes[index] = updateMap
+      this.setState({
+        arPlaneSizes: this.state.arPlaneSizes,
+      })
+    }
+  },
+
+  _onPlaneSelected(updateMap) {
+    this.props.onPlaneSelected && this.props.onPlaneSelected(updateMap)
+  },
+
+  /*
+  This function allows the user to reset the surface and select a new plane.
+  */
+  reset() {
+    this.setState({
+      selectedSurface: -1,
+    })
+  },
+})
+
+ViroMaterials.createMaterials({
+  ViroARPlaneSelector_Translucent: {
+    lightingModel: "Constant",
+    diffuseColor: "#88888888",
+  },
+})
+
+module.exports = ViroARPlaneSelector

--- a/src/views/screens/artab-screen/artab-screen.tsx
+++ b/src/views/screens/artab-screen/artab-screen.tsx
@@ -8,6 +8,7 @@ import {
   ActivityIndicator,
   Image,
   Linking,
+  Platform,
 } from "react-native"
 import { Text as SharedText } from "../../shared/text"
 import { presets } from "../../shared/text/text.presets"
@@ -111,6 +112,9 @@ export class ARTab extends React.Component {
   getTips() {
     let toReturn = []
     let tips = translate("arTab.tips")
+    if (Platform.OS == "android") {
+      tips = translate("arTab.tips-android")
+    }
     for (let tipIndex in tips) {
       toReturn.push(
         <View style={TIPCONTAINER} key={"tip" + tipIndex}>
@@ -162,11 +166,14 @@ export class ARTab extends React.Component {
   }
 
   render() {
+    let title = "arTab.title" + (Platform.OS == "android" ? "-android" : "")
+    let description = "arTab.description" + (Platform.OS == "android" ? "-android" : "")
+
     return (
       <Screen preset="fixed" backgroundColor={palette.portGore}>
         <Screen preset="scrollStack" backgroundColor={palette.portGore} style={{ width: "100%" }}>
-          <SharedText preset="title" tx="arTab.title" style={TITLE} />
-          <SharedText preset="body" tx="arTab.description" style={DESCRIPTION} />
+          <SharedText preset="title" tx={title} style={TITLE} />
+          <SharedText preset="body" tx={description} style={DESCRIPTION} />
           <SharedText preset="body" tx="arTab.tipsTitle" style={TITLE} />
           <View style={DIVIDER} />
 


### PR DESCRIPTION
The Android AR experience will no longer be badge-triggered, but instead will request that the user find and tap on a surface upon which the map will be rendered.