### PR TITLE
Fix bug with freeze when resuming in AR

### DIFF
--- a/src/navigation/stateful-navigator.tsx
+++ b/src/navigation/stateful-navigator.tsx
@@ -31,6 +31,15 @@ export class StatefulNavigator extends React.Component<StatefulNavigatorProps, {
       navigation.state.index = 1 // MainNavigator
       navigation.state.routes[1].index = 0 // Tabs
       navigation.state.routes[1].routes[0].index = 3 // AR Tab
+
+      // loop through the routes, find the route w/ name "arscreen" one
+      // and splice it out of the array
+      for (var i = 0; i < navigation.state.routes[1].routes.length; i++) {
+        if (navigation.state.routes[1].routes[i].routeName == "arscreen") {
+          navigation.state.routes[1].routes.splice(i, 1)
+          break
+        }
+      }
     }
     firstRun = false
 


### PR DESCRIPTION
From my last email the cause of this is:

```
1. User enters into AR Screen
2. User exits app
3. User enters app and triggers the code in /src/navigation/stateful-navigator.tsx (lines 26 to 35) which attempts to force the restoration of the navigation state to the AR Tab rather than the AR Screen.
4. Somehow the AR Screen is still being started up in the background and that causes our renderer to bug out because the size of the view is 0,0 (not rendered)
```

I was resetting the indexes of the navigation correctly, but not popping off the `arscreen` screen which caused the AR screen to attempt to load in the background.