### PR TITLE
Fix google link for the armory

### DIFF
--- a/src/views/screens/venue-screen/nearby-attractions/nearby-attractions.data.json
+++ b/src/views/screens/venue-screen/nearby-attractions/nearby-attractions.data.json
@@ -203,7 +203,7 @@
       "properties": {
         "place_address": "128 NW 11th Ave, Portland, Oregon 97209, United States",
         "place_name": "The Armory",
-        "place_link": "https://goo.gl/maps/GRNhPWacjtD2",
+        "place_link": "https://goo.gl/maps/8LxXt9CWaG72",
         "place_description": "Main conference venue."
       },
       "geometry": {


### PR DESCRIPTION
The google link to The Armory is wrong in the app. This replaces with a google link that takes users to the right map location.